### PR TITLE
Nest Cors Config under globalcors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Ignore target/ folder
+target/*
+
+# Ignore .vscode/ folder
+.vscode/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:17-jre-alpine
+
+RUN apk update && apk upgrade
+      
+WORKDIR /app
+      
+COPY target/*.jar /app/app.jar
+      
+EXPOSE 8125
+      
+CMD ["java", "-jar", "app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 # Standard port for Gateway Service:
 server:
   port: 8125
@@ -18,19 +17,20 @@ spring:
     name: gateway
   cloud:
     gateway:
-      cors-configurations:
-        # All routes:
-        '[/**]':
-          # Typical React port. Could also put your load balancer url here instead:
-          allowedOrigins: ${FRONTEND_URL:http://localhost:5176}
-          allowedHeaders: '*'
-          exposedHeaders: '*'
-          allowCredentials: true
-          allowedMethods:
-            - GET
-            - POST
-            - PUT
-            - DELETE
+      globalcors:
+        cors-configurations:
+          # All routes:
+          "[/**]":
+            # Typical React port. Could also put your load balancer url here instead:
+            allowedOrigins: ${FRONTEND_URL:http://localhost:5173}
+            allowedHeaders: "*"
+            exposedHeaders: "*"
+            allowCredentials: true
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
 
       # From the example we did in class. Will replace later but leaving this here so we can
       # use it as a guide once we start adding actual services:
@@ -88,13 +88,13 @@ spring:
         # Auth Service
         - id: auth-service
           uri: lb://auth-service
-          predicates: 
+          predicates:
             - Path=/auth/**
           # Auth Service Filter and CircuitBreaker
-          filters: 
+          filters:
             # - name: AuthenticationFilter
             - name: CircuitBreaker
-              args: 
+              args:
                 name: fallbackController
                 fallbackUri: forward:/cache/auth
             # Auth Service backoff:
@@ -142,7 +142,7 @@ spring:
           filters:
             # - name: AuthenticationFilter
             - name: CircuitBreaker
-              args: 
+              args:
                 name: fallbackController
                 fallbackUri: forward:/cache/accounts
             # Account Service backoff:
@@ -180,8 +180,6 @@ spring:
                   maxBackoff: 50ms
                   factor: 2
                   basedOnPreviousValue: false
-
-
 
 # Configure logging levels:
 logging:


### PR DESCRIPTION
This seemed to work for me when deploying the services. Something important to note is that each microservice can't have a different CORS configuration on their controllers. It might work if they specifically allow only localhost:5173 or whatever matches the gateway CORS config, but I'm not entirely sure.